### PR TITLE
Interceptação de erros lado servidor

### DIFF
--- a/src/LivrEtec.GIB.Servidor/EmprestimoServiceRPC.cs
+++ b/src/LivrEtec.GIB.Servidor/EmprestimoServiceRPC.cs
@@ -14,104 +14,62 @@ public sealed class EmprestimoServiceRPC : Emprestimos.EmprestimosBase
 	{
 		this.logger = logger;
 		this.emprestimoService = emprestimoService;
-        this.identidadeService = identidadeService as IdentidadeServiceRPC;
+		this.identidadeService = identidadeService as IdentidadeServiceRPC;
 	}
 
 	public override async Task<IdEmprestimo> Abrir(AbrirRequest request, ServerCallContext context)
 	{
-		try
+		identidadeService?.DefinirContexto(context);
+		return new IdEmprestimo()
 		{
-            identidadeService?.DefinirContexto(context);
-			return new IdEmprestimo()
-			{
-				Id = await emprestimoService.AbrirAsync(request.IdPessoa, request.IdLivro)
-			};
-		}
-		catch (Exception ex)
-		{
-			throw ManipuladorException.ExceptionToRpcException(ex);
-		}
+			Id = await emprestimoService.AbrirAsync(request.IdPessoa, request.IdLivro)
+		};
 	}
 
 	public override async Task<ListaEmprestimos> Buscar(BuscarRequest request, ServerCallContext context)
 	{
-		try
+		identidadeService?.DefinirContexto(context);
+		IEnumerable<Emprestimo> Emprestimos = await emprestimoService.BuscarAsync(new ParamBuscaEmprestimo(
+			IdLivro: request.IdLivro,
+			IdPessoa: request.IdPessoa,
+			Fechado: request.Fechado,
+			Atrasado: request.Atrasado
+		));
+		return new ListaEmprestimos()
 		{
-            identidadeService?.DefinirContexto(context);
-			IEnumerable<Emprestimo> Emprestimos = await emprestimoService.BuscarAsync(new ParamBuscaEmprestimo(
-				IdLivro: request.IdLivro,
-				IdPessoa: request.IdPessoa,
-				Fechado: request.Fechado,
-				Atrasado: request.Atrasado
-			));
-			return new ListaEmprestimos()
-			{
-				Emprestimos = { Emprestimos.Select(l => (RPC::Emprestimo)l).ToArray() }
-			};
-		}
-		catch (Exception ex)
-		{
-			throw ManipuladorException.ExceptionToRpcException(ex);
-		}
+			Emprestimos = { Emprestimos.Select(l => (RPC::Emprestimo)l).ToArray() }
+		};
 	}
-
 	public override async Task<Empty> Devolver(DevolverRequest request, ServerCallContext context)
 	{
-		try
-		{
-            identidadeService?.DefinirContexto(context);
-			await emprestimoService.DevolverAsync(
-				request.IdEmprestimo, 
-				request.HasAtrasoJustificado ? request.AtrasoJustificado : null, 
-				request.HasExplicacaoAtraso ? request.ExplicacaoAtraso : null
-			);
-		}
-		catch (Exception ex)
-		{
-			throw ManipuladorException.ExceptionToRpcException(ex);
-		}
+		identidadeService?.DefinirContexto(context);
+		await emprestimoService.DevolverAsync(
+			request.IdEmprestimo,
+			request.HasAtrasoJustificado ? request.AtrasoJustificado : null,
+			request.HasExplicacaoAtraso ? request.ExplicacaoAtraso : null
+		);
 		return new Empty();
 	}
 
-
 	public override async Task<Empty> Prorrogar(ProrrogarRequest request, ServerCallContext context)
 	{
-		try
-		{
-            identidadeService?.DefinirContexto(context);
-			await emprestimoService.ProrrogarAsnc(request.IdEmprestimo, request.NovaData.ToDateTime());
-		}
-		catch (Exception ex)
-		{
-			throw ManipuladorException.ExceptionToRpcException(ex);
-		}
+		identidadeService?.DefinirContexto(context);
+		await emprestimoService.ProrrogarAsnc(request.IdEmprestimo, request.NovaData.ToDateTime());
 		return new Empty();
 	}
 
 	public override async Task<Empty> RegistrarPerda(IdEmprestimo request, ServerCallContext context)
 	{
-		try
-		{
-            identidadeService?.DefinirContexto(context);
-			await emprestimoService.RegistrarPerdaAsync(request.Id);
-		}
-		catch (Exception ex)
-		{
-			throw ManipuladorException.ExceptionToRpcException(ex);
-		}
+		identidadeService?.DefinirContexto(context);
+		await emprestimoService.RegistrarPerdaAsync(request.Id);
 		return new Empty();
 	}
+
 	public override async Task<Empty> Excluir(IdEmprestimo request, ServerCallContext context)
 	{
-		try
-		{
-            identidadeService?.DefinirContexto(context);
-			await emprestimoService.ExcluirAsync(request.Id);
-		}
-		catch (Exception ex)
-		{
-			throw ManipuladorException.ExceptionToRpcException(ex);
-		}
+		identidadeService?.DefinirContexto(context);
+		await emprestimoService.ExcluirAsync(request.Id);
 		return new Empty();
 	}
+
 }

--- a/src/LivrEtec.GIB.Servidor/ExceptionInterceptor.cs
+++ b/src/LivrEtec.GIB.Servidor/ExceptionInterceptor.cs
@@ -1,0 +1,21 @@
+using Grpc.Core;
+using Grpc.Core.Interceptors;
+
+namespace LivrEtec.GIB.Servidor;
+public class ExceptionInterceptor: Interceptor
+{
+    public override async Task<TResponse> UnaryServerHandler<TRequest, TResponse>(
+        TRequest request,
+        ServerCallContext context,
+        UnaryServerMethod<TRequest, TResponse> continuation)
+    {
+        try
+        {
+            return await continuation(request, context);
+        }
+        catch (Exception ex)
+        {
+			throw ManipuladorException.ExceptionToRpcException(ex);
+        }
+    }
+}

--- a/src/LivrEtec.GIB.Servidor/LivrosServiceRPC.cs
+++ b/src/LivrEtec.GIB.Servidor/LivrosServiceRPC.cs
@@ -3,72 +3,47 @@ using LivrEtec.GIB.RPC;
 
 namespace LivrEtec.GIB.Servidor
 {
-    public sealed class LivrosServiceRPC : Livros.LivrosBase
-    {
-        readonly ILogger<LivrosServiceRPC> logger;
-        readonly ILivrosService livrosService;
-        public LivrosServiceRPC(ILogger<LivrosServiceRPC> logger, ILivrosService livrosService)
-        {
-            this.logger = logger;
-            this.livrosService = livrosService;
-        }
-
-
-        public override async Task<Empty> Registrar(RPC.Livro request, ServerCallContext context)
+	public sealed class LivrosServiceRPC : Livros.LivrosBase
+	{
+		readonly ILogger<LivrosServiceRPC> logger;
+		readonly ILivrosService livrosService;
+		public LivrosServiceRPC(ILogger<LivrosServiceRPC> logger, ILivrosService livrosService)
 		{
-            try {
-			    await livrosService.RegistrarAsync(request);
-            }
-            catch (Exception ex) {
-                throw ManipuladorException.ExceptionToRpcException(ex);
-            }
-            return new Empty();
+			this.logger = logger;
+			this.livrosService = livrosService;
+		}
+
+
+		public override async Task<Empty> Registrar(RPC.Livro request, ServerCallContext context)
+		{
+			await livrosService.RegistrarAsync(request);
+			return new Empty();
 
 		}
 		public override async Task<RPC.Livro?> Get(IdLivro request, ServerCallContext context)
-        {
-            try{
-                return await livrosService.GetAsync(request.Id);
-            }
-            catch (Exception ex) {
-                throw ManipuladorException.ExceptionToRpcException(ex);
-            }
-        }
+		{
+			return await livrosService.GetAsync(request.Id);
+		}
 
-        public override async Task<Empty> Remover(RPC.IdLivro request, ServerCallContext context)
-        {
-            try {
-                await livrosService.RemoverAsync(request.Id);
-            }
-            catch (Exception ex) {
-                throw ManipuladorException.ExceptionToRpcException(ex);
-            }
-            return new Empty();
-        }
+		public override async Task<Empty> Remover(RPC.IdLivro request, ServerCallContext context)
+		{
+			await livrosService.RemoverAsync(request.Id);
+			return new Empty();
+		}
 
-        public override async Task<ListaLivros> Buscar(ParamBusca request, ServerCallContext context)
-        {
-            
-            try{
-				IEnumerable<Livro> Livros = await livrosService.BuscarAsync(request.NomeLivro, request.NomeAutor, request.IdTags);
-				return new ListaLivros() { 
-                    Livros = { Livros.Select(l=> (RPC.Livro)l).ToArray() }
-                };
-            }
-            catch (Exception ex) {
-                throw ManipuladorException.ExceptionToRpcException(ex);
-            }
-        }
+		public override async Task<ListaLivros> Buscar(ParamBusca request, ServerCallContext context)
+		{
+			IEnumerable<Livro> Livros = await livrosService.BuscarAsync(request.NomeLivro, request.NomeAutor, request.IdTags);
+			return new ListaLivros()
+			{
+				Livros = { Livros.Select(l => (RPC.Livro)l).ToArray() }
+			};
+		}
 
-        public override async Task<Empty> Editar(RPC.Livro request, ServerCallContext context)
-        {
-            try{
-                await livrosService.EditarAsync(request);
-            }
-            catch (Exception ex) {
-                throw ManipuladorException.ExceptionToRpcException(ex);
-            }
-            return new Empty();
-        }
-    }
+		public override async Task<Empty> Editar(RPC.Livro request, ServerCallContext context)
+		{
+			await livrosService.EditarAsync(request);
+			return new Empty();
+		}
+	}
 }

--- a/src/LivrEtec.GIB.Servidor/Program.cs
+++ b/src/LivrEtec.GIB.Servidor/Program.cs
@@ -9,7 +9,10 @@ var builder = WebApplication.CreateBuilder(args);
 
 // Additional configuration is required to successfully run gRPC on macOS.
 // For instructions on how to configure Kestrel and gRPC clients on macOS, visit https://go.microsoft.com/fwlink/?linkid=2099682
-builder.Services.AddGrpc();
+builder.Services.AddGrpc( options => {
+    options.Interceptors.Add<ExceptionInterceptor>();
+    
+});
 
 
 builder.Logging.ClearProviders();

--- a/src/LivrEtec.GIB.Servidor/TagssServiceRPC.cs
+++ b/src/LivrEtec.GIB.Servidor/TagssServiceRPC.cs
@@ -4,73 +4,50 @@ using static LivrEtec.GIB.RPC.Tag.Types;
 
 namespace LivrEtec.GIB.Servidor
 {
-    public sealed class TagsServiceRPC : Tags.TagsBase
-    {
-        readonly ILogger<TagsServiceRPC> logger;
-        readonly ITagsService tagsService;
-        public TagsServiceRPC(ILogger<TagsServiceRPC> logger, ITagsService tagsService)
-        {
-            this.logger = logger;
-            this.tagsService = tagsService;
-        }
-
-
-        public override async Task<IdTag> Registrar(RPC.Tag request, ServerCallContext context)
+	public sealed class TagsServiceRPC : Tags.TagsBase
+	{
+		readonly ILogger<TagsServiceRPC> logger;
+		readonly ITagsService tagsService;
+		public TagsServiceRPC(ILogger<TagsServiceRPC> logger, ITagsService tagsService)
 		{
-            try {
-			    return new IdTag(){
-                    Id = await tagsService.RegistrarAsync(request)
-                };
-            }
-            catch (Exception ex) {
-                throw ManipuladorException.ExceptionToRpcException(ex);
-            }
+			this.logger = logger;
+			this.tagsService = tagsService;
+		}
+
+
+		public override async Task<IdTag> Registrar(RPC.Tag request, ServerCallContext context)
+		{
+			return new IdTag()
+			{
+				Id = await tagsService.RegistrarAsync(request)
+			};
 
 		}
 		public override async Task<RPC.Tag?> Obter(IdTag request, ServerCallContext context)
-        {
-            try{
-                return await tagsService.ObterAsync(request.Id);
-            }
-            catch (Exception ex) {
-                throw ManipuladorException.ExceptionToRpcException(ex);
-            }
-        }
+		{
+			return await tagsService.ObterAsync(request.Id);
+		}
 
-        public override async Task<Empty> Remover(RPC.IdTag request, ServerCallContext context)
-        {
-            try {
-                await tagsService.RemoverAsync(request.Id);
-            }
-            catch (Exception ex) {
-                throw ManipuladorException.ExceptionToRpcException(ex);
-            }
-            return new Empty();
-        }
+		public override async Task<Empty> Remover(RPC.IdTag request, ServerCallContext context)
+		{
+			await tagsService.RemoverAsync(request.Id);
+			return new Empty();
+		}
 
-        public override async Task<ListaTags> Buscar(BuscarRequest request, ServerCallContext context)
-        {
-            
-            try{
-				IEnumerable<Tag> Tags = await tagsService.BuscarAsync(request.Nome);
-				return new ListaTags() { 
-                    Tags = { Tags.Select(l=> (RPC.Tag)l).ToArray() }
-                };
-            }
-            catch (Exception ex) {
-                throw ManipuladorException.ExceptionToRpcException(ex);
-            }
-        }
+		public override async Task<ListaTags> Buscar(BuscarRequest request, ServerCallContext context)
+		{
 
-        public override async Task<Empty> Editar(RPC.Tag request, ServerCallContext context)
-        {
-            try{
-                await tagsService.EditarAsync(request);
-            }
-            catch (Exception ex) {
-                throw ManipuladorException.ExceptionToRpcException(ex);
-            }
-            return new Empty();
-        }
-    }
+			IEnumerable<Tag> Tags = await tagsService.BuscarAsync(request.Nome);
+			return new ListaTags()
+			{
+				Tags = { Tags.Select(l => (RPC.Tag)l).ToArray() }
+			};
+		}
+
+		public override async Task<Empty> Editar(RPC.Tag request, ServerCallContext context)
+		{
+			await tagsService.EditarAsync(request);
+			return new Empty();
+		}
+	}
 }

--- a/src/LivrEtec.GIB/EmprestimoServiceRPC.cs
+++ b/src/LivrEtec.GIB/EmprestimoServiceRPC.cs
@@ -80,7 +80,7 @@ namespace LivrEtec.GIB
         public async Task ExcluirAsync(int idEmprestimo)
 		{
             try{
-                
+
                 await clientRPC.ExcluirAsync(new IdEmprestimo (){
                     Id = idEmprestimo,
                 });


### PR DESCRIPTION
Foi criado o interceptador ExceptionInterceptor, que converte as exceções normais em exceções RPC, assim reduzindo a quantidade de try-catch na API. Era para também ter sido adicionado ao lado do cliente, porem por algum motivo o interceptador não esta pegando as exceções do lado do cliente.