### PR TITLE
Adiciona à api a função de escolher do banco de dados

### DIFF
--- a/src/Docker/GIB_Servidor/appsettings.json
+++ b/src/Docker/GIB_Servidor/appsettings.json
@@ -2,8 +2,11 @@
   "AuthKey": "48dcf01d97de1113c45c7a61346c00cd9cd904775a7851127b43ceee77676c1c",
   "SenhaPadraoAdmin": "senha",
   "ConnectionStrings": {
-    "MySql": "server=db;database=LivrEtecBD;user=LivrEtecServe;password=LivrEtecSenha;"
+    "MySql": "server=db;database=LivrEtecBD;user=LivrEtecServe;password=LivrEtecSenha;",
+    "Sqlite": "DataSource=LivrEtecTeste.db" 
   },
+
+  "DataBase": "MySql",
   "Logging": {
     "LogLevel": {
       "Default": "Information",

--- a/src/LivrEtec.GIB/LivrEtec.GIB.csproj
+++ b/src/LivrEtec.GIB/LivrEtec.GIB.csproj
@@ -13,6 +13,7 @@
     <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="6.0.13" />
     <PackageReference Include="Microsoft.ApplicationInsights.AspNetCore" Version="2.15.0" />
 	<PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="7.0.0" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="6.0.7" />
 </ItemGroup>
 <ItemGroup>
   <ProjectReference Include="..\LivrEtec\LivrEtec.csproj" />

--- a/src/LivrEtec.GIB/Program.cs
+++ b/src/LivrEtec.GIB/Program.cs
@@ -88,16 +88,22 @@ builder.Host.UseSerilog((context, services, configuration) =>
 
 builder.Services.AddDbContextFactory<PacaContext>((options) =>
 {
-	var strConexao = builder.Configuration.GetConnectionString("MySql");
-	options.UseMySql(strConexao, ServerVersion.AutoDetect(strConexao));
+	String strConexao;
+	switch(builder.Configuration["DataBase"]?.ToLower()){
+		case "mysql":
+			strConexao = builder.Configuration.GetConnectionString("MySql");
+			options.UseMySql(strConexao, ServerVersion.AutoDetect(strConexao));
+			break;
+		case "sqlite": 
+		default: 
+			strConexao = builder.Configuration.GetConnectionString("Sqlite");
+			options.UseSqlite(strConexao);
+			break;
+	}
 });
 
 
-builder.Services.AddControllers();
-builder.Services.AddDbContextFactory<PacaContext>(( options )=>{
-    var strConexao = builder.Configuration.GetConnectionString("MySql");
-    options.UseMySql(strConexao, ServerVersion.AutoDetect(strConexao));
-});
+builder.Services.AddControllers(); 
 builder.Services.AddSingleton<IRelogio, RelogioSistema>();
 builder.Services.AddScoped<PacaContext>();
 builder.Services.AddScoped<IRepUsuarios, RepUsuarios>();
@@ -134,6 +140,7 @@ app.MapControllers();
 using (var scope = app.Services.CreateScope()){
 	using var BD = scope.ServiceProvider.GetRequiredService<PacaContext>();
 	var logger = scope.ServiceProvider.GetRequiredService<ILogger<PacaContext>>();
+	logger.LogInformation($"Usando o banco de dados: {builder.Configuration["DataBase"]?.ToLower()}");
 	logger.LogTrace("Verificando se bando de dados existe...");
 	
 	if(BD.Database.EnsureCreated()) {

--- a/src/LivrEtec.GIB/appsettings.modelo.json
+++ b/src/LivrEtec.GIB/appsettings.modelo.json
@@ -5,12 +5,13 @@
   // De preferencia um Hash Aleatorio 
   "AuthKey": "",
   // Insira aqui a senha do administrador quando o banco de dados ser criado pela primeira vez
-  "SenhaPadraoAdmin": "Senha",
+  "SenhaPadraoAdmin": "Senha", // Essa senha gera o hash: 92F20DAFC5E5AC1C66820903C492CC04
   "ConnectionStrings": {
     // Insira aqui a string de conexão do mysql
-    "MySql": "server=;database=;user=;password=;"
+    "MySql": "server=;database=;user=;password=;",
+    "Sqlite": "DataSource=livretec.db;"
   },
-  
+  "DataBase": "mysql" // Possiveis valores (sqlite caso nenhum seja usado): "mysql", "sqlite"
   "AllowedHosts": "*",
   "Kestrel": {
     "EndpointDefaults": {


### PR DESCRIPTION
Adiciona SQLite ao servidor, e quando o programa começa, ele verifica via o appsettings se deve usar MySQL ou SQLite Também feita duas pequenas mudanças, que é adicinando o comentario do hash padrão que vem na senha do appsettings modelo, e também removido um trecho de codigo repetido